### PR TITLE
Switch remodiffuse pipeline to flow matching

### DIFF
--- a/configs/remodiffuse/remodiffuse_kit.py
+++ b/configs/remodiffuse/remodiffuse_kit.py
@@ -82,7 +82,7 @@ index_num = 3
 
 # model settings
 model = dict(
-    type='MotionDiffusion',
+    type='MotionFlowMatching',
     loss_weight=dict(
         # motion_w=0,
         # index_w=0
@@ -91,6 +91,13 @@ model = dict(
     ),
     index_num=index_num,
     motion_crop=[4, 21*3+4],
+    flow=dict(
+        time_scale=1000,
+        solver=dict(
+            type='euler',
+            num_steps=60,
+        ),
+    ),
     model=dict(
         type='ReMoDiffuseTransformer',
         input_feats=input_feats,
@@ -140,18 +147,4 @@ model = dict(
         )
     ),
     loss_recon=dict(type='MSELoss', loss_weight=1, reduction='none'),
-    diffusion_train=dict(
-        beta_scheduler='linear',
-        diffusion_steps=1000,
-        model_mean_type='start_x',
-        model_var_type='fixed_large',
-    ),
-    diffusion_test=dict(
-        beta_scheduler='linear',
-        diffusion_steps=1000,
-        model_mean_type='start_x',
-        model_var_type='fixed_large',
-        respace='15,15,8,6,6',
-    ),
-    inference_type='ddim'
 )

--- a/configs/remodiffuse/remodiffuse_kit.py
+++ b/configs/remodiffuse/remodiffuse_kit.py
@@ -58,7 +58,7 @@ workflow = [('train', 1)]
 
 # optimizer
 optimizer = dict(type='Adam', lr=2e-4)
-lr_scheduler = dict(milestone_ratios=[5/6], gamma=0.1)
+lr_scheduler = dict(milestone_ratios=[0.5, 5/6], gamma=0.1)
 optimizer_config = dict(grad_clip=None)
 # learning policy
 # lr_config = dict(policy='CosineAnnealing', min_lr_ratio=0, by_epoch=False)

--- a/configs/remodiffuse/remodiffuse_kit.py
+++ b/configs/remodiffuse/remodiffuse_kit.py
@@ -94,6 +94,11 @@ model = dict(
     motion_crop=[4, 21*3+4],
     flow=dict(
         time_scale=1000,
+        path=dict(
+            type='rectified',
+            exponent=2.0,
+            epsilon=1e-4,
+        ),
         solver=dict(
             type='euler',
             num_steps=60,

--- a/configs/remodiffuse/remodiffuse_kit.py
+++ b/configs/remodiffuse/remodiffuse_kit.py
@@ -93,11 +93,20 @@ model = dict(
     index_num=index_num,
     motion_crop=[4, 21*3+4],
     flow=dict(
+        kind='rectified',
         time_scale=1000,
         path=dict(
             type='rectified',
             exponent=2.0,
             epsilon=1e-4,
+        ),
+        objective=dict(
+            motion=1.0,
+            velocity=1.0,
+        ),
+        variance=dict(
+            type='alpha',
+            floor=1e-4,
         ),
         solver=dict(
             type='euler',

--- a/configs/remodiffuse/remodiffuse_kit.py
+++ b/configs/remodiffuse/remodiffuse_kit.py
@@ -109,7 +109,7 @@ model = dict(
             floor=1e-4,
         ),
         solver=dict(
-            type='euler',
+            type='heun',
             num_steps=60,
         ),
     ),

--- a/configs/remodiffuse/remodiffuse_kit.py
+++ b/configs/remodiffuse/remodiffuse_kit.py
@@ -58,6 +58,7 @@ workflow = [('train', 1)]
 
 # optimizer
 optimizer = dict(type='Adam', lr=2e-4)
+lr_scheduler = dict(milestone_ratios=[5/6], gamma=0.1)
 optimizer_config = dict(grad_clip=None)
 # learning policy
 # lr_config = dict(policy='CosineAnnealing', min_lr_ratio=0, by_epoch=False)

--- a/configs/remodiffuse/remodiffuse_kit.py
+++ b/configs/remodiffuse/remodiffuse_kit.py
@@ -162,4 +162,18 @@ model = dict(
         )
     ),
     loss_recon=dict(type='MSELoss', loss_weight=1, reduction='none'),
+    diffusion_train=dict(
+        beta_scheduler='linear',
+        diffusion_steps=1000,
+        model_mean_type='start_x',
+        model_var_type='fixed_large',
+    ),
+    diffusion_test=dict(
+        beta_scheduler='linear',
+        diffusion_steps=1000,
+        model_mean_type='start_x',
+        model_var_type='fixed_large',
+        respace='15,15,8,6,6',
+    ),
+    inference_type='ddim'
 )

--- a/configs/remodiffuse/remodiffuse_t2m.py
+++ b/configs/remodiffuse/remodiffuse_t2m.py
@@ -156,4 +156,18 @@ model = dict(
         )
     ),
     loss_recon=dict(type='MSELoss', loss_weight=1, reduction='none'),
+    diffusion_train=dict(
+        beta_scheduler='linear',
+        diffusion_steps=1000,
+        model_mean_type='start_x',
+        model_var_type='fixed_large',
+    ),
+    diffusion_test=dict(
+        beta_scheduler='linear',
+        diffusion_steps=1000,
+        model_mean_type='start_x',
+        model_var_type='fixed_large',
+        respace='15,15,8,6,6',
+    ),
+    inference_type='ddim'
 )

--- a/configs/remodiffuse/remodiffuse_t2m.py
+++ b/configs/remodiffuse/remodiffuse_t2m.py
@@ -87,11 +87,20 @@ model = dict(
     index_num=index_num,
     motion_crop=[4, 22*3+4],
     flow=dict(
+        kind='rectified',
         time_scale=1000,
         path=dict(
             type='rectified',
             exponent=2.0,
             epsilon=1e-4,
+        ),
+        objective=dict(
+            motion=1.0,
+            velocity=1.0,
+        ),
+        variance=dict(
+            type='alpha',
+            floor=1e-4,
         ),
         solver=dict(
             type='euler',

--- a/configs/remodiffuse/remodiffuse_t2m.py
+++ b/configs/remodiffuse/remodiffuse_t2m.py
@@ -88,6 +88,11 @@ model = dict(
     motion_crop=[4, 22*3+4],
     flow=dict(
         time_scale=1000,
+        path=dict(
+            type='rectified',
+            exponent=2.0,
+            epsilon=1e-4,
+        ),
         solver=dict(
             type='euler',
             num_steps=60,

--- a/configs/remodiffuse/remodiffuse_t2m.py
+++ b/configs/remodiffuse/remodiffuse_t2m.py
@@ -55,7 +55,7 @@ workflow = [('train', 1)]
 
 # optimizer
 optimizer = dict(type='Adam', lr=2e-4)
-lr_scheduler = dict(milestone_ratios=[5/6], gamma=0.1)
+lr_scheduler = dict(milestone_ratios=[0.5, 5/6], gamma=0.1)
 optimizer_config = dict(grad_clip=None)
 # learning policy
 # lr_config = dict(policy='CosineAnnealing', min_lr_ratio=2e-5, by_epoch=False)

--- a/configs/remodiffuse/remodiffuse_t2m.py
+++ b/configs/remodiffuse/remodiffuse_t2m.py
@@ -79,12 +79,19 @@ index_num = 3
 
 # model settings
 model = dict(
-    type='MotionDiffusion',
+    type='MotionFlowMatching',
     loss_weight=dict(
         motion_w=1,
     ),
     index_num=index_num,
     motion_crop=[4, 22*3+4],
+    flow=dict(
+        time_scale=1000,
+        solver=dict(
+            type='euler',
+            num_steps=60,
+        ),
+    ),
     model=dict(
         type='ReMoDiffuseTransformer',
         input_feats=input_feats,
@@ -134,18 +141,4 @@ model = dict(
         )
     ),
     loss_recon=dict(type='MSELoss', loss_weight=1, reduction='none'),
-    diffusion_train=dict(
-        beta_scheduler='linear',
-        diffusion_steps=1000,
-        model_mean_type='start_x',
-        model_var_type='fixed_large',
-    ),
-    diffusion_test=dict(
-        beta_scheduler='linear',
-        diffusion_steps=1000,
-        model_mean_type='start_x',
-        model_var_type='fixed_large',
-        respace='15,15,8,6,6',
-    ),
-    inference_type='ddim'
 )

--- a/configs/remodiffuse/remodiffuse_t2m.py
+++ b/configs/remodiffuse/remodiffuse_t2m.py
@@ -55,6 +55,7 @@ workflow = [('train', 1)]
 
 # optimizer
 optimizer = dict(type='Adam', lr=2e-4)
+lr_scheduler = dict(milestone_ratios=[5/6], gamma=0.1)
 optimizer_config = dict(grad_clip=None)
 # learning policy
 # lr_config = dict(policy='CosineAnnealing', min_lr_ratio=2e-5, by_epoch=False)

--- a/configs/remodiffuse/remodiffuse_t2m.py
+++ b/configs/remodiffuse/remodiffuse_t2m.py
@@ -103,7 +103,7 @@ model = dict(
             floor=1e-4,
         ),
         solver=dict(
-            type='euler',
+            type='heun',
             num_steps=60,
         ),
     ),

--- a/mogen/apis/lg_train.py
+++ b/mogen/apis/lg_train.py
@@ -18,6 +18,7 @@ class LgModel(LightningModule):
         self.dataset = dataset
         self.outputs = []
         self.unit = unit
+        self.last_aits = None
 
     
     def on_train_epoch_start(self) -> None:
@@ -95,7 +96,16 @@ class LgModel(LightningModule):
                 ordered_results.extend(list(res))
             ordered_results = ordered_results[:len(self.dataset)]
             print(f'StiSim:{1-evalute_sim(ordered_results, joints_num=21)/evalute_mean(ordered_results, joints_num=21)}')
+            inference_times = [res.get('inference_time', 0.0) for res in ordered_results if 'inference_time' in res]
+            avg_inference = sum(inference_times) / len(inference_times) if inference_times else 0.0
+            if inference_times:
+                print(f'\nAITS : {avg_inference:.6f}s')
+                self.last_aits = avg_inference
+            else:
+                self.last_aits = None
             results = self.dataset.evaluate(ordered_results)
+            if inference_times:
+                results['AITS'] = avg_inference
             for k, v in results.items():
                 print(f'\n{k} : {v:.4f}')
 

--- a/mogen/apis/lg_train.py
+++ b/mogen/apis/lg_train.py
@@ -19,6 +19,7 @@ class LgModel(LightningModule):
         self.outputs = []
         self.unit = unit
         self.last_aits = None
+        self.last_solver_steps = None
 
     
     def on_train_epoch_start(self) -> None:
@@ -103,6 +104,13 @@ class LgModel(LightningModule):
                 self.last_aits = avg_inference
             else:
                 self.last_aits = None
+            solver_steps = [res.get('solver_steps') for res in ordered_results if 'solver_steps' in res]
+            if solver_steps:
+                avg_steps = sum(solver_steps) / len(solver_steps)
+                print(f'\nAverage solver steps : {avg_steps:.2f}')
+                self.last_solver_steps = avg_steps
+            else:
+                self.last_solver_steps = None
             results = self.dataset.evaluate(ordered_results)
             if inference_times:
                 results['AITS'] = avg_inference

--- a/mogen/apis/lg_train.py
+++ b/mogen/apis/lg_train.py
@@ -1,3 +1,5 @@
+from collections import Counter
+
 import torch
 import torch.optim as optim
 from mogen.core.optimizer.builder import build_optimizers
@@ -105,12 +107,20 @@ class LgModel(LightningModule):
             else:
                 self.last_aits = None
             solver_steps = [res.get('solver_steps') for res in ordered_results if 'solver_steps' in res]
+            solver_evals = [res.get('solver_evals') for res in ordered_results if 'solver_evals' in res]
+            solver_types = [res.get('solver_type') for res in ordered_results if 'solver_type' in res]
             if solver_steps:
                 avg_steps = sum(solver_steps) / len(solver_steps)
                 print(f'\nAverage solver steps : {avg_steps:.2f}')
                 self.last_solver_steps = avg_steps
             else:
                 self.last_solver_steps = None
+            if solver_evals:
+                avg_evals = sum(solver_evals) / len(solver_evals)
+                print(f'Average solver evaluations : {avg_evals:.2f}')
+            if solver_types:
+                primary_type = Counter(solver_types).most_common(1)[0][0]
+                print(f'Solver type : {primary_type}')
             results = self.dataset.evaluate(ordered_results)
             if inference_times:
                 results['AITS'] = avg_inference

--- a/mogen/models/architectures/__init__.py
+++ b/mogen/models/architectures/__init__.py
@@ -1,6 +1,7 @@
 from .vae_architecture import MotionVAE
 from .diffusion_architecture import MotionDiffusion
+from .flow_matching_architecture import MotionFlowMatching
 
 __all__ = [
-    'MotionVAE', 'MotionDiffusion'
+    'MotionVAE', 'MotionDiffusion', 'MotionFlowMatching'
 ]

--- a/mogen/models/architectures/__init__.py
+++ b/mogen/models/architectures/__init__.py
@@ -1,7 +1,17 @@
 from .vae_architecture import MotionVAE
 from .diffusion_architecture import MotionDiffusion
-from .flow_matching_architecture import MotionFlowMatching
+from .flow_matching_architecture import (
+    MotionFlowMatching,
+    MotionNaiveFlowMatching,
+    MotionRectifiedFlowMatching,
+    MotionMeanFlowMatching,
+)
 
 __all__ = [
-    'MotionVAE', 'MotionDiffusion', 'MotionFlowMatching'
+    'MotionVAE',
+    'MotionDiffusion',
+    'MotionFlowMatching',
+    'MotionNaiveFlowMatching',
+    'MotionRectifiedFlowMatching',
+    'MotionMeanFlowMatching',
 ]

--- a/mogen/models/architectures/base_architecture.py
+++ b/mogen/models/architectures/base_architecture.py
@@ -120,6 +120,8 @@ class BaseArchitecture(BaseModule):
             batch_output['pred_motion'] = to_cpu(results['pred_motion'][i])
             batch_output['motion_length'] = to_cpu(results['motion_length'][i])
             batch_output['motion_mask'] = to_cpu(results['motion_mask'][i])
+            if 'inference_time' in results:
+                batch_output['inference_time'] = float(to_cpu(results['inference_time'][i]))
             if 'pred_motion_length' in results.keys():
                 batch_output['pred_motion_length'] = to_cpu(results['pred_motion_length'][i])
             else:

--- a/mogen/models/architectures/base_architecture.py
+++ b/mogen/models/architectures/base_architecture.py
@@ -124,6 +124,10 @@ class BaseArchitecture(BaseModule):
                 batch_output['inference_time'] = float(to_cpu(results['inference_time'][i]))
             if 'solver_steps' in results:
                 batch_output['solver_steps'] = float(to_cpu(results['solver_steps'][i]))
+            if 'solver_evals' in results:
+                batch_output['solver_evals'] = float(to_cpu(results['solver_evals'][i]))
+            if 'solver_type' in results:
+                batch_output['solver_type'] = results['solver_type'][i]
             if 'pred_motion_length' in results.keys():
                 batch_output['pred_motion_length'] = to_cpu(results['pred_motion_length'][i])
             else:

--- a/mogen/models/architectures/base_architecture.py
+++ b/mogen/models/architectures/base_architecture.py
@@ -122,6 +122,8 @@ class BaseArchitecture(BaseModule):
             batch_output['motion_mask'] = to_cpu(results['motion_mask'][i])
             if 'inference_time' in results:
                 batch_output['inference_time'] = float(to_cpu(results['inference_time'][i]))
+            if 'solver_steps' in results:
+                batch_output['solver_steps'] = float(to_cpu(results['solver_steps'][i]))
             if 'pred_motion_length' in results.keys():
                 batch_output['pred_motion_length'] = to_cpu(results['pred_motion_length'][i])
             else:

--- a/mogen/models/architectures/diffusion_architecture.py
+++ b/mogen/models/architectures/diffusion_architecture.py
@@ -89,6 +89,7 @@ class MotionDiffusion(BaseArchitecture):
         self.motion_start = motion_crop[0]
         self.motion_end = motion_crop[1]
         self.index_num = index_num
+        self.last_solver_steps = None
         
     def others_cuda(self):
         device = [v for k,v in self.model.named_parameters()][0].device
@@ -197,8 +198,16 @@ class MotionDiffusion(BaseArchitecture):
             elapsed = time.perf_counter() - start_time
             per_sample_time = elapsed / max(B, 1)
             results = kwargs
+            steps = getattr(self.diffusion_test, 'num_timesteps', None)
+            if steps is not None:
+                self.last_solver_steps = float(steps)
+                step_tensor = output["sample"].new_full((B,), float(steps))
+            else:
+                self.last_solver_steps = None
+                step_tensor = output["sample"].new_full((B,), 0.0)
             results['pred_motion'] = output["sample"]
             results['pred_index'] = output["index"]
+            results['solver_steps'] = step_tensor
             results['inference_time'] = output["sample"].new_full((B,), per_sample_time)
             results = self.split_results(results)
             return results

--- a/mogen/models/architectures/diffusion_architecture.py
+++ b/mogen/models/architectures/diffusion_architecture.py
@@ -161,14 +161,15 @@ class MotionDiffusion(BaseArchitecture):
             return loss
         else:
             dim_pose = kwargs['motion'].shape[-1]
+            if motion.device.type == "cuda":
+                torch.cuda.synchronize(motion.device)
+            start_time = time.perf_counter()
+
             model_kwargs = self.model.get_precompute_condition(device=motion.device,  **kwargs)
             model_kwargs['motion_mask'] = motion_mask
             model_kwargs['sample_idx'] = sample_idx
             model_kwargs['motion_length'] = kwargs['motion_length']
             inference_kwargs = kwargs.get('inference_kwargs', {})
-            if motion.device.type == "cuda":
-                torch.cuda.synchronize(motion.device)
-            start_time = time.perf_counter()
 
             if self.inference_type == 'ddpm':
                 output = self.diffusion_test.p_sample_loop(

--- a/mogen/models/architectures/flow_matching_architecture.py
+++ b/mogen/models/architectures/flow_matching_architecture.py
@@ -449,4 +449,7 @@ class MotionMeanFlowMatching(MotionFlowMatching):
     def __init__(self, flow=None, **kwargs):
         flow_cfg = dict(flow or {})
         flow_cfg.setdefault("kind", "meanflow")
+        # MeanFlow benefits from the rectified (ReFlow-style) schedule by default.
+        path_cfg = flow_cfg.setdefault("path", {})
+        path_cfg.setdefault("type", "rectified")
         super().__init__(flow=flow_cfg, **kwargs)

--- a/mogen/models/architectures/flow_matching_architecture.py
+++ b/mogen/models/architectures/flow_matching_architecture.py
@@ -1,0 +1,300 @@
+import torch
+
+from .base_architecture import BaseArchitecture
+from ..builder import (
+    ARCHITECTURES,
+    build_submodule,
+    build_loss,
+)
+
+
+@ARCHITECTURES.register_module()
+class MotionFlowMatching(BaseArchitecture):
+    """Flow-matching architecture built on top of the existing transformer."""
+
+    def __init__(
+        self,
+        model=None,
+        loss_recon=None,
+        loss_weight=None,
+        flow=None,
+        init_cfg=None,
+        index_num=None,
+        motion_crop=None,
+        **kwargs,
+    ):
+        super().__init__(init_cfg=init_cfg, **kwargs)
+        self.model = build_submodule(model)
+        self.loss_recon = build_loss(loss_recon)
+        self.loss_weight = loss_weight or {}
+        self.index_num = index_num
+        self.motion_start = motion_crop[0]
+        self.motion_end = motion_crop[1]
+
+        flow = flow or {}
+        solver = flow.get("solver", {})
+        self.time_scale = float(flow.get("time_scale", 1000.0))
+        self.default_solver_steps = int(solver.get("num_steps", 50))
+        self.default_solver_type = solver.get("type", "euler").lower()
+
+        # cache stickman geometry for default fallbacks during inference
+        if hasattr(self.model, "multistick_encoder"):
+            stick_encoder = self.model.multistick_encoder.stick_encoder
+            # stick encoder consumes (point_len * 2) features per polyline
+            point_len = stick_encoder.proj_in.in_features // 2
+            self._stickman_shape = (self.index_num, 6, point_len, 2)
+        else:
+            self._stickman_shape = None
+
+    # ------------------------------------------------------------------
+    # helper utilities
+    # ------------------------------------------------------------------
+    def _get_default_stickman(self, batch_size, device):
+        if self._stickman_shape is None:
+            return None
+        index_num, num_segments, point_len, point_dim = self._stickman_shape
+        return torch.zeros(
+            batch_size,
+            index_num,
+            num_segments,
+            point_len,
+            point_dim,
+            device=device,
+        )
+
+    # ------------------------------------------------------------------
+    # device helpers
+    # ------------------------------------------------------------------
+    def others_cuda(self):
+        device = next(self.model.parameters()).device
+        self.model.to(device)
+
+    # ------------------------------------------------------------------
+    # core forward
+    # ------------------------------------------------------------------
+    def forward(self, **kwargs):
+        return_loss = kwargs.pop("return_loss", True)
+        motion = kwargs["motion"].float()
+        motion_mask = kwargs["motion_mask"].float()
+        motion_length = kwargs["motion_length"]
+        specified_idx = kwargs.get("specified_idx", None)
+        stickman_tracks = kwargs.get("stickman_tracks", None)
+        sample_idx = kwargs.get("sample_idx", None)
+        clip_feat = kwargs.get("clip_feat", None)
+        text = [meta.get("text", "") for meta in kwargs.get("motion_metas", [{} for _ in range(motion.shape[0])])]
+
+        device = motion.device
+        B, T, dim_pose = motion.shape
+
+        if specified_idx is None:
+            specified_idx = torch.zeros(B, self.index_num, dtype=torch.long, device=device)
+        else:
+            specified_idx = specified_idx.to(device=device, dtype=torch.long)
+
+        if stickman_tracks is None:
+            default_track = self._get_default_stickman(B, device)
+            if default_track is None:
+                raise ValueError("stickman_tracks must be provided for this configuration.")
+            stickman_tracks = default_track
+        else:
+            stickman_tracks = stickman_tracks.to(device=device, dtype=torch.float32)
+
+        if sample_idx is not None:
+            sample_idx = sample_idx.to(device)
+
+        if clip_feat is not None:
+            clip_feat = clip_feat.to(device)
+
+        if self.training and return_loss:
+            return self._forward_train(
+                motion=motion,
+                motion_mask=motion_mask,
+                motion_length=motion_length,
+                specified_idx=specified_idx,
+                stickman_tracks=stickman_tracks,
+                sample_idx=sample_idx,
+                clip_feat=clip_feat,
+                text=text,
+            )
+        else:
+            return self._forward_test(
+                motion=motion,
+                motion_mask=motion_mask,
+                motion_length=motion_length,
+                specified_idx=specified_idx,
+                stickman_tracks=stickman_tracks,
+                sample_idx=sample_idx,
+                clip_feat=clip_feat,
+                text=text,
+                inference_kwargs=kwargs.get("inference_kwargs", {}),
+                raw_kwargs=kwargs,
+            )
+
+    # ------------------------------------------------------------------
+    # training
+    # ------------------------------------------------------------------
+    def _forward_train(
+        self,
+        motion,
+        motion_mask,
+        motion_length,
+        specified_idx,
+        stickman_tracks,
+        sample_idx,
+        clip_feat,
+        text,
+    ):
+        device = motion.device
+        B = motion.shape[0]
+
+        base_sample = torch.randn_like(motion)
+        t = torch.rand(B, device=device)
+        # Linear conditional flow path: x_t = (1 - t) * x0 + t * x1
+        xt = (1.0 - t)[:, None, None] * base_sample + t[:, None, None] * motion
+        scaled_t = t * self.time_scale
+
+        pred_velocity, index, p_batch, stick_mask = self.model(
+            xt,
+            scaled_t,
+            motion_mask=motion_mask,
+            motion_length=motion_length,
+            text=text,
+            specified_idx=specified_idx,
+            stickman_tracks=stickman_tracks,
+            sample_idx=sample_idx,
+            clip_feat=clip_feat,
+        )
+        pred = base_sample + pred_velocity
+        target = motion
+
+        all_loss = 0.0
+        loss = {}
+        all_loss_batch = self.loss_recon(pred, target, reduction_override="none")
+        specified_motion = motion[torch.arange(B, device=device)[:, None], specified_idx, :]
+
+        loss_item = ["text_loss", "both_loss", "stick_loss", "none_loss"]
+        assert len(p_batch) == len(loss_item)
+        all_batch = sum(p_batch)
+        start = 0
+        for i, batch in enumerate(p_batch):
+            if batch == 0:
+                loss[loss_item[i]] = torch.tensor(0.0, device=device)
+                continue
+            segment_slice = slice(start, start + batch)
+            if loss_item[i] in {"both_loss", "stick_loss"}:
+                spec_m = specified_motion[segment_slice, :, self.motion_start : self.motion_end]
+                pred_m = pred[segment_slice, :, self.motion_start : self.motion_end]
+                spec_loss = []
+                for j in range(self.index_num):
+                    diff = (spec_m[:, j, None] - pred_m).pow(2).mean(-1)
+                    w_m = index[segment_slice, :, j]
+                    stick_cond_mask = stick_mask[segment_slice, j, 0]
+                    spec_loss.append(((diff * w_m).sum(-1) * stick_cond_mask).sum() / batch)
+                loss[f"identity_{loss_item[i]}"] = sum(spec_loss) / len(spec_loss)
+                all_loss = all_loss + batch / all_batch * loss[f"identity_{loss_item[i]}"] * self.loss_weight.get("motion_w", 1.0)
+            masked_mse = (
+                all_loss_batch[segment_slice].mean(-1) * motion_mask[segment_slice]
+            ).sum() / motion_mask[segment_slice].sum()
+            loss[loss_item[i]] = masked_mse
+            all_loss = all_loss + batch / all_batch * masked_mse
+            start += batch
+        loss["all_loss"] = all_loss
+        return loss
+
+    # ------------------------------------------------------------------
+    # inference utilities
+    # ------------------------------------------------------------------
+    def _flow_solver(self, x, motion_mask, motion_length, specified_idx, stickman_tracks, sample_idx, clip_feat, text, inference_kwargs):
+        device = x.device
+        solver_cfg = inference_kwargs.get("solver", {})
+        method = solver_cfg.get("type", self.default_solver_type)
+        steps = int(solver_cfg.get("num_steps", self.default_solver_steps))
+        if steps <= 0:
+            raise ValueError("Number of solver steps must be positive.")
+        if method != "euler":
+            raise NotImplementedError(f"Solver '{method}' is not supported yet.")
+
+        if motion_mask.dim() == 2:
+            mask = motion_mask.unsqueeze(-1)
+        else:
+            mask = motion_mask
+
+        precomputed = self.model.get_precompute_condition(
+            text=text,
+            stickman_tracks=stickman_tracks,
+            motion_length=motion_length,
+            device=device,
+            sample_idx=sample_idx,
+            clip_feat=clip_feat,
+        )
+        step_times = torch.linspace(0.0, 1.0, steps + 1, device=device)
+        for i in range(steps):
+            t_cur = step_times[i]
+            t_next = step_times[i + 1]
+            dt = t_next - t_cur
+            t_batch = torch.full((x.shape[0],), t_cur * self.time_scale, device=device)
+            velocity, index = self.model(
+                x,
+                t_batch,
+                motion_mask=motion_mask,
+                motion_length=motion_length,
+                xf_out=precomputed["xf_out"],
+                stick_encoder=precomputed["stick_encoder"],
+                sample_idx=sample_idx,
+            )
+            if mask is not None:
+                velocity = velocity * mask
+            x = x + dt * velocity
+        final_t = torch.full((x.shape[0],), self.time_scale, device=device)
+        _, index = self.model(
+            x,
+            final_t,
+            motion_mask=motion_mask,
+            motion_length=motion_length,
+            xf_out=precomputed["xf_out"],
+            stick_encoder=precomputed["stick_encoder"],
+            sample_idx=sample_idx,
+        )
+        return x, index
+
+    def _forward_test(
+        self,
+        motion,
+        motion_mask,
+        motion_length,
+        specified_idx,
+        stickman_tracks,
+        sample_idx,
+        clip_feat,
+        text,
+        inference_kwargs,
+        raw_kwargs,
+    ):
+        device = motion.device
+        B, T, D = motion.shape
+
+        base = inference_kwargs.get("base", "standard_normal")
+        if base != "standard_normal":
+            raise NotImplementedError(f"Base distribution '{base}' is not supported.")
+        x = torch.randn(B, T, D, device=device)
+
+        pred_motion, pred_index = self._flow_solver(
+            x,
+            motion_mask,
+            motion_length,
+            specified_idx,
+            stickman_tracks,
+            sample_idx,
+            clip_feat,
+            text,
+            inference_kwargs,
+        )
+
+        if getattr(self.model, "post_process", None) is not None:
+            pred_motion = self.model.post_process(pred_motion)
+
+        results = dict(raw_kwargs)
+        results.pop("return_loss", None)
+        results["pred_motion"] = pred_motion
+        results["pred_index"] = pred_index
+        return self.split_results(results)

--- a/mogen/models/architectures/flow_matching_architecture.py
+++ b/mogen/models/architectures/flow_matching_architecture.py
@@ -26,7 +26,12 @@ class MotionFlowMatching(BaseArchitecture):
         motion_crop=None,
         **kwargs,
     ):
-        super().__init__(init_cfg=init_cfg, **kwargs)
+        # ``kwargs`` may contain configuration entries intended for other
+        # architectures (e.g., ``diffusion_train`` when toggling models from
+        # the CLI).  ``BaseArchitecture`` does not accept arbitrary keyword
+        # arguments, so avoid forwarding them and only pass the supported
+        # ``init_cfg``.
+        super().__init__(init_cfg=init_cfg)
         self.model = build_submodule(model)
         self.loss_recon = build_loss(loss_recon)
         self.loss_weight = loss_weight or {}

--- a/tools/lg_test.py
+++ b/tools/lg_test.py
@@ -83,15 +83,17 @@ def main():
         pid_seed = os.getppid()
     model = LgModel(cfg, dataset, unit=hashlib.md5(str(pid_seed).encode()).hexdigest()[:8])
     test_loader = DataLoader(dataset, batch_size=cfg.data.samples_per_gpu, shuffle=False, num_workers=cfg.data.workers_per_gpu, collate_fn=collate_fn)
-    trainer = Trainer(accelerator="gpu", 
+    trainer = Trainer(accelerator="gpu",
                       strategy=DDPStrategy(),
                     #   devices=[0],
                       devices=parse_gpu(args.gpu),
-                      logger=False, 
+                      logger=False,
                     #   max_steps=3,
                       precision='16-mixed',
                       )
     trainer.validate(model, test_loader, ckpt_path=args.ckpt)
+    if getattr(model, 'last_aits', None) is not None:
+        print(f'\nAverage inference time per sample: {model.last_aits:.6f}s')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add a MotionFlowMatching architecture that reuses the existing transformer as a flow predictor and integrates a simple Euler solver for sampling
- update remodiffuse configs to opt into the new flow-matching setup and drop legacy diffusion parameters
- extend the visualization script to provide required stickman inputs and allow configuring the flow solver when running inference

## Testing
- python -m compileall mogen/models/architectures/flow_matching_architecture.py tools/visualize.py

------
https://chatgpt.com/codex/tasks/task_e_68f6b6ae0980832da4d6bd0ae6b6b77d